### PR TITLE
Change php.ini to meet rest module requirements

### DIFF
--- a/resources/conf/php.ini
+++ b/resources/conf/php.ini
@@ -1,5 +1,6 @@
 memory_limit=512M
 date.timezone=America/Chicago
+always_populate_raw_post_data=-1
 [xdebug]
 zend_extension=xdebug.so
 xdebug.max_nesting_level=256


### PR DESCRIPTION
The always_populate_raw_post_data PHP setting should be set to -1 in PHP versions 5.6 and up.
