### PR TITLE
Update platform default web root

### DIFF
--- a/src/Platform.php
+++ b/src/Platform.php
@@ -11,7 +11,7 @@ class Platform
 {
     const REPOSITORY_DIR = 'repository';
     const SHARED_DIR = 'shared';
-    const DEFAULT_WEB_ROOT = 'www';
+    const DEFAULT_WEB_ROOT = '_www';
     const TEST_ROOT = 'tests';
 
     /**


### PR DESCRIPTION
They've changed it since it was 'www' - not once but twice! See https://github.com/platformsh/platformsh-cli/search?q=_www&type=Commits&utf8=%E2%9C%93