### PR TITLE
MySQL shouldn't be started as root.

### DIFF
--- a/resources/conf/mysql.cnf
+++ b/resources/conf/mysql.cnf
@@ -8,7 +8,7 @@ socket		= /var/run/mysqld/mysqld.sock
 nice		= 0
 
 [mysqld]
-user		= root
+user		= mysql
 pid-file	= /var/run/mysqld/mysqld.pid
 socket		= /var/run/mysqld/mysqld.sock
 port		= 3306


### PR DESCRIPTION
When starting the docker compose, in Ubuntu 16.04, mysql container exits with code 1 because of:
`mariadb_1  | Cannot change ownership of the database directories to the 'root'`
The service should be started as `mysql` user.