### PR TITLE
Set private file locations correctly for platform build command

### DIFF
--- a/resources/stacks/drupal7/settings.local.php
+++ b/resources/stacks/drupal7/settings.local.php
@@ -41,3 +41,6 @@ if (empty($_SERVER['PLATFORM_DOCKER'])) {
       'prefix' => '',
     );
 }
+
+// Set the private file path to where a "platform build" command creates one.
+$conf['file_private_path'] = '../private';

--- a/resources/stacks/drupal8/settings.local.php
+++ b/resources/stacks/drupal8/settings.local.php
@@ -48,6 +48,9 @@ if (empty($_SERVER['PLATFORM_DOCKER'])) {
     );
 }
 
+// Set the private file path to where a "platform build" command creates one.
+$settings['file_private_path'] = '../private';
+
 // Configuration directories.
 $config_directories = array(
   CONFIG_ACTIVE_DIRECTORY => '../shared/config/active',


### PR DESCRIPTION
We know the location of private files after a platform build - we should set it correcting in the local.settings.php