### PR TITLE
Fix mysql on linux

### DIFF
--- a/resources/conf/mysql.cnf
+++ b/resources/conf/mysql.cnf
@@ -8,7 +8,9 @@ socket		= /var/run/mysqld/mysqld.sock
 nice		= 0
 
 [mysqld]
-user		= root
+# Make no assumptions about what user is running mysqld since docker can mess with this. This caused problems on Ubuntu
+# 16.04 and Mint 17
+# user		= root
 pid-file	= /var/run/mysqld/mysqld.pid
 socket		= /var/run/mysqld/mysqld.sock
 port		= 3306


### PR DESCRIPTION
Testing this on linux reveal an interesting problem with the MariaDb container. After doing a build the maria container was not running. Doing a ```docker-compose up``` in the project root revealed:
```
docker-compose  up
Recreating cmsvision_mariadb_1
Recreating cmsvision_phpfpm_1
Recreating cmsvision_nginx_1
Attaching to cmsvision_mariadb_1, cmsvision_phpfpm_1, cmsvision_nginx_1
mariadb_1  | Initializing database
mariadb_1  | chown: changing ownership of '/var/lib/mysql/': Operation not permitted
mariadb_1  | Cannot change ownership of the database directories to the 'root'
mariadb_1  | user.  Check that you have the necessary permissions and try again.
phpfpm_1   | [31-Mar-2017 11:31:48] NOTICE: fpm is running, pid 1
phpfpm_1   | [31-Mar-2017 11:31:48] NOTICE: ready to handle connections
cmsvision_mariadb_1 exited with code 1
```

The change attached fixed it.